### PR TITLE
Feature infer license

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The steps are:
 * **--aws-role-policy** : (Optional) Name of the policy assigned to the AWS role. Supply a name if you want to create the role with a restricted policy (only Lambda permissions). Omit the parameter to create the role with the AWS default [`ReadOnlyAccess` policy](https://docs.newrelic.com/docs/integrations/amazon-integrations/getting-started/integrations-managed-policies).
 * **--linked-account-name** *LINKED_ACCOUNT_NAME* : Name of your AWS account that will appear in NR Cloud integrations. It is used to easily identify your account in NR. The cloud account will be created if it does not exist yet.
 * **--nr-api-key** *NR_API_KEY* : Your New Relic User API key (different from New Relic REST API key!). [Check the documentation](https://docs.newrelic.com/docs/apis/getting-started/intro-apis/understand-new-relic-api-keys#user-api-key) on how to obtain a user API key.
-* **--nr-license-key** *NR_LICENSE_KEY* : Your New Relic license key. [Check the documentation](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key) on how to obtain a license key.
 * **--regions** *REGIONS* : (Optional) List of regions where to install the New Relic log ingestion function. If no value is supplied it will fetch the list of regions from EC2 and use that as the list of regions.
+* **--nr-region** *NR_REGION* : (Optional) Set to "eu" if you're integrating with the New Relic EU region. Defaults to US. 
 
 **Note**: if this command fails with the error `(UnrecognizedClientException) when calling the GetFunction operation: The security token included in the request is invalid.`, it is commonly because there was no region supplied. Just add the --regions flag with your authorized regions,  then run the command again and it should pass.
 
@@ -108,7 +108,6 @@ The steps are:
     --linked-account-name "account_name" \
     --aws-role-policy "NewRelicLambdaPolicy" \
     --nr-api-key "api_key" \
-    --nr-license-key "license_key" \
     --regions "region_1" "region-2"
 ```
 
@@ -140,7 +139,7 @@ It will not check for required permissions either in AWS or New Relic.
 * **--nr-account-id** *NR_ACCOUNT_ID* : Your New Relic account id.
 * **--linked-account-name** *LINKED_ACCOUNT_NAME* : Name of your AWS account that appears in NR Cloud integrations you want to check.
 * **--nr-api-key** *NR_API_KEY* : Your New Relic user API key. Check the documentation on how to obtain an API key.
-* **--nr-license-key** *NR_LICENSE_KEY* : Your New Relic license key. Check the documentation on how to obtain an license key.
+* **--nr-region** *NR_REGION* : (Optional) Set to "eu" if you're integrating with the New Relic EU region. Defaults to US. 
 * **--functions** *FUNCTIONS* : List of (space-separated) function names to check.
 * **--regions** *REGIONS* (Optional) List of (space-separated) regions where to perform the checks.
 
@@ -151,7 +150,6 @@ It will not check for required permissions either in AWS or New Relic.
 --nr-account-id "account_id" \
 --linked-account-name "account_name" \
 --nr-api-key "api_key" \
---nr-license-key "license_key" \
 --functions "my-function-1" "my-function-2" \
 --regions "region_1" "region_2"
 ```

--- a/newrelic-cloud
+++ b/newrelic-cloud
@@ -129,6 +129,28 @@ class NewRelicGraphQLClient:
         account = response['data']['actor']['account']
         return account['cloud']['linkedAccounts']
 
+    def get_license_key(self):
+        query = '''
+            query($accountId: Int!) {
+              requestContext {
+                apiKey
+              }
+              actor {
+                account(id: $accountId) {
+                  licenseKey
+                  id
+                  name
+                }
+              }
+            }
+            '''
+        params = {'accountId': self.nr_account_id}
+        response = self._execute_query(query=query, params=params)
+        self._raise_if_failed(response)
+        account = response['data']['actor']['account']
+
+        return account['licenseKey']
+
     def get_linked_account_by_name(self, account_name):
         """
         return a specific linked account of the current New Relic account
@@ -273,8 +295,8 @@ def list_all_regions():
             'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
 
 
-def get_endpoint(nr_license_key):
-    if nr_license_key.startswith("eu"):
+def get_endpoint(nr_region):
+    if nr_region == "eu":
         debug_print('Using GraphQL EU endpoint for GraphQL API')
         return _GRAPHQL_EU_API_URL
     else:
@@ -547,14 +569,16 @@ def enable_lambda_monitoring(args):
     nr_account_id = args['nr_account_id']
     linked_account_name = args['linked_account_name']
     role_policy = args['aws_role_policy']
-    nr_license_key = args['nr_license_key']
+    nr_region = args['nr_region']
     api_key = args['nr_api_key']
     regions = args['regions']
 
     results = []
-    api_endpoint = get_endpoint(nr_license_key)
+    api_endpoint = get_endpoint(nr_region)
     api_client = NewRelicGraphQLClient(nr_account_id, api_key, api_endpoint)
     try:
+        print("Validating credentials and retrieving integration license key")
+        nr_license_key = api_client.get_license_key()
 
         validate_linked_account(linked_account_name, api_client)
 
@@ -611,11 +635,11 @@ def check_lambda_setup(args):
     nr_account_id = args['nr_account_id']
     linked_account_name = args['linked_account_name']
     api_key = args['nr_api_key']
-    nr_license_key = args['nr_license_key']
+    nr_region = args['nr_region']
     function_names = args['functions']
     regions = args['regions']
 
-    api_endpoint = get_endpoint(nr_license_key)
+    api_endpoint = get_endpoint(nr_region)
     api_client = NewRelicGraphQLClient(nr_account_id, api_key, api_endpoint)
 
     results = []
@@ -714,9 +738,8 @@ def main():
     lambda_parser.add_argument('--nr-api-key', required=True,
       help=('Your New Relic user API key. '
             'Check the documentation on how to obtain an API key.'))
-    lambda_parser.add_argument('--nr-license-key', required=True,
-      help=('Your New Relic license key. '
-            'Check the documentation on how to obtain an license key.'))
+    lambda_parser.add_argument('--nr-region', default="us",
+      help=('(Optional) "eu" to use the New Relic EU region'))
     lambda_parser.add_argument('--regions', nargs='+',
       help=('(Optional) List of (space-separated) regions where the log '
             'ingestion function will be installed.'))
@@ -744,9 +767,8 @@ def main():
     status_parser.add_argument('--nr-api-key', required=True,
       help=('Your New Relic user API key. '
             'Check the documentation on how to obtain an API key.'))
-    status_parser.add_argument('--nr-license-key', required=True,
-      help=('Your New Relic license key. '
-            'Check the documentation on how to obtain an license key.'))
+    status_parser.add_argument('--nr-region', default="us",
+      help=('(Optional) "eu" to use the New Relic EU region'))
     status_parser.add_argument('--functions', required=True, nargs='+',
       help='List of (space-separated) function names to set up log streaming.')
     status_parser.add_argument('--regions', nargs='+',

--- a/newrelic-cloud
+++ b/newrelic-cloud
@@ -6,8 +6,10 @@ import json
 from datetime import datetime
 try:
     import urllib.request as urlrequest
+    from urllib.error import HTTPError
 except ImportError:
     import urllib2 as urlrequest
+    from urllib2 import HTTPError
 import collections
 
 # compatibility with python 2.6+
@@ -47,6 +49,7 @@ _DOCS_CONFIGURE_AWS_CLI_LINK = 'https://docs.aws.amazon.com/cli/latest/userguide
 _DOCS_CONNECT_ACCOUNT_LINK = 'https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#connect-aws'
 _DOCS_INSTRUMENT_LAMBDA_LINK = 'https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#instrument-lambda'
 _DOCS_STREAM_LOGS_LINK = 'https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#stream-logs'
+_DOCS_NR_API_KEY_LINK = 'https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key'
 
 class NewRelicGraphQLClient:
 
@@ -130,6 +133,10 @@ class NewRelicGraphQLClient:
         return account['cloud']['linkedAccounts']
 
     def get_license_key(self):
+        """
+        Fetch the license key for this NR Account. Validates that the nr-api-key is correct, that this API key
+        can access the account, and attempts to provide helpful messages if anything goes wrong.
+        """
         query = '''
             query($accountId: Int!) {
               requestContext {
@@ -145,7 +152,19 @@ class NewRelicGraphQLClient:
             }
             '''
         params = {'accountId': self.nr_account_id}
-        response = self._execute_query(query=query, params=params)
+        try:
+            response = self._execute_query(query=query, params=params)
+        except HTTPError as e:
+            if e.code == 401:
+                print("\nUnauthorized error when querying New Relic. Make sure that your New Relic API Key is correct.\nFind your API Key: %s" % _DOCS_NR_API_KEY_LINK)
+                if not self.api_key.startswith("NRAK-"):
+                    print("Valid New Relic API Keys generally start with \"NRAK-\". You supplied %s" % self.api_key)
+            raise e
+
+        if "errors" in response:
+            if len([e for e in response["errors"] if e["message"] == "Access denied."]) > 0:
+                print("\nCouldn't find New Relic Account ID %d using this API key, but the API Key appears valid. Is that the right account ID?" % self.nr_account_id)
+
         self._raise_if_failed(response)
         account = response['data']['actor']['account']
 

--- a/newrelic-cloud
+++ b/newrelic-cloud
@@ -738,7 +738,7 @@ def main():
     lambda_parser.add_argument('--nr-api-key', required=True,
       help=('Your New Relic user API key. '
             'Check the documentation on how to obtain an API key.'))
-    lambda_parser.add_argument('--nr-region', default="us",
+    lambda_parser.add_argument('--nr-region', default="us", choices=('eu', 'us'),
       help=('(Optional) "eu" to use the New Relic EU region'))
     lambda_parser.add_argument('--regions', nargs='+',
       help=('(Optional) List of (space-separated) regions where the log '
@@ -767,7 +767,7 @@ def main():
     status_parser.add_argument('--nr-api-key', required=True,
       help=('Your New Relic user API key. '
             'Check the documentation on how to obtain an API key.'))
-    status_parser.add_argument('--nr-region', default="us",
+    status_parser.add_argument('--nr-region', default="us", choices=('eu', 'us'),
       help=('(Optional) "eu" to use the New Relic EU region'))
     status_parser.add_argument('--functions', required=True, nargs='+',
       help='List of (space-separated) function names to set up log streaming.')


### PR DESCRIPTION
Removes the license key parameter, fetching it automatically instead, using the GraphQL API.

Also attempts to diagnose common problems with the API key, to improve the onboarding experience.