### PR TITLE
Bump Lambda to 2.0.1

### DIFF
--- a/templates/newrelic-log-ingestion.yaml
+++ b/templates/newrelic-log-ingestion.yaml
@@ -12,6 +12,6 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:463657938898:applications/NewRelic-log-ingestion
-        SemanticVersion: 2.0.0
+        SemanticVersion: 2.0.1
       Parameters:
         NRLicenseKey: !Ref NewRelicLicenseKey


### PR DESCRIPTION
This picks up the bug fix here: https://github.com/newrelic/aws-log-ingestion/commit/0ad3cd00cb78d21df2a7b4d6ede5dc65d829166a

Verified that running `newrelic-cloud set-up-lambda-integration` creates the lambda with the bug fix.